### PR TITLE
Feature: Use squidclient for unit test

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,11 +1,20 @@
 version: '2'
 services:
   proxy:
-    build: .
+    image: squidproxy
+    build:
+      context: .
+      dockerfile: Dockerfile
+    healthcheck:
+      test: ["CMD", "sh", "-exc", "squidclient -T 3 mgr:info 2> /dev/null | grep -qF '200 OK'"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 1s
   sut:
-    image: alpine:3.10.1
+    image: squidproxy
     links: 
       - proxy
     depends_on:
       - proxy
-    command: sh -exc "apk add --update curl && sleep 5 && exec curl --proxy http://proxy:3128 -I http://google.com/"
+    command: sh -exc "sleep 10 && squidclient -h proxy -T 3 'https://postman-echo.com/get?squidtest=ok' 2> /dev/null | grep -qF '200 OK'"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   proxy:
     image: squidproxy

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   proxy:
     image: squidproxy


### PR DESCRIPTION
Changed `docker-compose.test.yml` to use `squidclient`
- reuse of the same image for build and test
- insertion of healtcheck into proxy service
- usage of `squidclient` in `sut` service
- URL check against postman echo service because it is a declared test service and it can return 200 OK (e.g. google.com return 301)
- usage of `grep` is not ideal but `squidclient` does not use exit status to distinguish between http return codes